### PR TITLE
11 unwarranted warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ An additional flag is used:
 | `--variables` | `-v` | Variables to send. If not provided, all variables will be sent. If set to `compact`, the variables will not be sent to separate Zarr files. |
 | `--reproject` | `-r` | Whether to reproject data. If not provided, the data is not reprojected. If present, reproject the data from tri-polar grid to PlateCarree.
 | `--chunk-strategy` | `-cs` | Chunk strategy in the output data. If provided, the output data will be chunked according to the specified strategy. If not provided, it will use the `auto` mode. The format is a JSON string, e.g., '{"time_counter": 1, "x": 100, "y": 100}'.
+| `--skip-integrity-check` | `-si` | Whether to skip data integrity check. If not provided, the integrity checks will be applied to the data in order to check if the uploaded data is OK.
 
 ## Credentials File
 
@@ -95,10 +96,12 @@ If a chunk strategy is specified, the output data will be chunked accordingly. I
 
 ### Check Data Integrity
 
-Every time new data is appended to an existing Zarr file, integrity checks are performed to verify if the metadata and data match the expected format.
+Every time new data is appended to an existing Zarr file, it is possible to perform some integrity checks to verify if the metadata and data match the expected format.
 
 1. Metadata check: Each new NetCDF file sent to the object store will have its metadata checked, including the number and names of variables and coordinates. If there are discrepancies, a specific error is raised.
 
 2. Data check: The checksum of the data in the NetCDF file is compared with the data in the Zarr file after upload. If they differ, an error is raised.
 
 If any errors are detected during these checks, the data is rolled back to the previous version. This rollback is performed directly in the Zarr file by updating the metadata to exclude the new data. The system will retry the upload twice more; if it fails again, a message is logged.
+
+The integrity check may take a while and slow down to upload process. Because of that, if you want to skip this check, you can add set the `skip_integrity_check` to false when you are sending a file to the object store.

--- a/examples/n06_dataset_example.ipynb
+++ b/examples/n06_dataset_example.ipynb
@@ -4179,7 +4179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/msm_os/cli/argument_parser.py
+++ b/src/msm_os/cli/argument_parser.py
@@ -79,6 +79,15 @@ def create_parser():
         help="If present, reproject data",
         default=False,
     )
+    
+    parser.add_argument(
+        "-si",
+        "--skip-integrity-check",
+        dest="skip_integrity_check",
+        action='store_true',
+        help="If present, skip the integrity check of the output files",
+        default=False,
+    )
 
     parser.add_argument(
         "-cs",

--- a/src/msm_os/cli/main_cli.py
+++ b/src/msm_os/cli/main_cli.py
@@ -61,6 +61,7 @@ def process_action(args):
             object_prefix=args.object_prefix,
             rechunk=args.chunk_strategy,
             reproject=args.reproject,
+            skip_integrity_check=args.skip_integrity_check,
             to_zarr_kwargs=None,
         )
 

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -427,8 +427,9 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
     # Apply custom chunking if the dimensions are present
     # chunking = {"x": 100, "y": 100, "time_counter": 1}
     variables = ds_filepath.variables
-
+    print(variables)
     for variable in variables:
+        print(variable)
         new_chunking = {
             dim: size
             for dim, size in rechunk.items()
@@ -438,6 +439,8 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
             ds_filepath[variable] = ds_filepath[
                 variable
             ].chunk(new_chunking)
+            print(ds_filepath[variable].chunks)
+            
     return ds_filepath
 
 def _reproject_ds(ds_filepath: xr.Dataset, var: str) -> xr.Dataset:

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -363,7 +363,11 @@ def _send_variable(
                 )
 
                 if chunks_differ:
-                    logging.warning("You already have data in the object store and you can't rechunk it")
+                    logging.warning("The actual data on the object store has chunk size: %s", actual_data_chunksize)
+                    logging.warning("And you are trying to rechunk it to: %s", new_chunking)
+                    logging.warning("You can't rechunk the data on the object store")
+                    # logging.warning("You already have data in the object store and you can't rechunk it")
+
                 # ds_filepath_var = _rechunk_ds(ds_filepath_var, rechunk)
 
             # Append the variable to the object store
@@ -418,6 +422,8 @@ def _send_variable(
                                 object_prefix,
                                 var,
                                 append_dim)
+    else:
+        logging.warning("As requested, skipping data integrity check for %s", dest)
 
 
 def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
@@ -432,9 +438,7 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
     # Apply custom chunking if the dimensions are present
     # chunking = {"x": 100, "y": 100, "time_counter": 1}
     variables = ds_filepath.variables
-    print(variables)
     for variable in variables:
-        print(variable)
         new_chunking = {
             dim: size
             for dim, size in rechunk.items()
@@ -444,7 +448,6 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
             ds_filepath[variable] = ds_filepath[
                 variable
             ].chunk(new_chunking)
-            print(ds_filepath[variable].chunks)
             
     return ds_filepath
 

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -349,14 +349,19 @@ def _send_variable(
 
             # Rechunk the dataset
             if rechunk:
-                actual_data_chunksize = {dim: chunk[0] for dim, chunk in zip(ds_filepath_var[var].dims,
-                                                                             ds_filepath_var[var].chunks)}
+                actual_data_chunksize = {dim: chunk[0] for dim, chunk in zip(ds_obj_store[var].dims,
+                                                                             ds_obj_store[var].chunks) if chunk}
                 new_chunking = {
                     dim: size
                     for dim, size in rechunk.items()
                     if dim in ds_filepath[var].dims
                 }
-                chunks_differ = any(actual_data_chunksize[dim] != new_chunking[dim] for dim in new_chunking)
+
+                chunks_differ = any(
+                    dim in actual_data_chunksize and actual_data_chunksize[dim] != new_chunking[dim]
+                    for dim in new_chunking
+                )
+
                 if chunks_differ:
                     logging.warning("You already have data in the object store and you can't rechunk it")
                 # ds_filepath_var = _rechunk_ds(ds_filepath_var, rechunk)

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -366,8 +366,6 @@ def _send_variable(
                     logging.warning("The actual data on the object store has chunk size: %s", actual_data_chunksize)
                     logging.warning("And you are trying to rechunk it to: %s", new_chunking)
                     logging.warning("You can't rechunk the data on the object store")
-                    # logging.warning("You already have data in the object store and you can't rechunk it")
-
                 # ds_filepath_var = _rechunk_ds(ds_filepath_var, rechunk)
 
             # Append the variable to the object store
@@ -445,9 +443,11 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
             if dim in ds_filepath[variable].dims
         }
         if len(new_chunking.keys()) > 0:
+            print(f"Rechunking {variable} to {new_chunking}")
             ds_filepath[variable] = ds_filepath[
                 variable
             ].chunk(new_chunking)
+            print(f"New chunking: {ds_filepath[variable].chunks}")
             
     return ds_filepath
 

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -443,11 +443,9 @@ def _rechunk_ds(ds_filepath: xr.Dataset, rechunk: dict) -> xr.Dataset:
             if dim in ds_filepath[variable].dims
         }
         if len(new_chunking.keys()) > 0:
-            print(f"Rechunking {variable} to {new_chunking}")
             ds_filepath[variable] = ds_filepath[
                 variable
             ].chunk(new_chunking)
-            print(f"New chunking: {ds_filepath[variable].chunks}")
             
     return ds_filepath
 

--- a/src/msm_os/object_store_handler.py
+++ b/src/msm_os/object_store_handler.py
@@ -23,12 +23,11 @@ from .exceptions import (
     CheckSumMismatch,
 )
 from .object_store import ObjectStoreS3
-from .sanity_cheks import (
+from .sanity_checks import (
     calculate_metadata,
     check_destination_exists,
     check_duplicates,
     check_variable_exists,
-    check_data_integrity,
     data_integrity_evaluation,
 )
 
@@ -113,6 +112,7 @@ def send(
     client: Optional[Client] = None,#
     rechunk: dict = None,
     reproject: bool = False,
+    skip_integrity_check: bool = False,
     to_zarr_kwargs: Optional[dict] = None,
 ) -> None:
     """
@@ -141,6 +141,8 @@ def send(
         Rechunk strategy dictionary, by default None.
     reproject
         Whether to reproject the dataset, by default False.
+    skip_integrity_check
+        Whether to skip the data integrity check, by default False.
     to_zarr_kwargs
         Additional keyword arguments passed to xr.Dataset.to_zarr(), by default None.
     """
@@ -168,6 +170,7 @@ def send(
             client,
             rechunk,
             reproject,
+            skip_integrity_check,
             to_zarr_kwargs,
         )
 
@@ -285,6 +288,7 @@ def _send_variable(
     append_dim: str,
     rechunk: dict,
     reproject: bool = False,
+    skip_integrity_check: bool = True,
 ) -> None:
     """
     Send a single variable to the object store.
@@ -308,6 +312,8 @@ def _send_variable(
         Whether to rechunk the dataset.
     reproject
         Whether to reproject the dataset.
+    skip_integrity_check
+        Whether to skip the data integrity check.
     """
     check_variable_exists(ds_filepath, var)
     ds_filepath_var = ds_filepath[[var]]
@@ -343,14 +349,23 @@ def _send_variable(
 
             # Rechunk the dataset
             if rechunk:
-                logging.warning("You already have data in the object store and you can't rechunk it")
-                # logging.warning("The actual chunk size is %s", ds_filepath_var[var].data.chunksize)
+                actual_data_chunksize = {dim: chunk[0] for dim, chunk in zip(ds_filepath_var[var].dims,
+                                                                             ds_filepath_var[var].chunks)}
+                new_chunking = {
+                    dim: size
+                    for dim, size in rechunk.items()
+                    if dim in ds_filepath[var].dims
+                }
+                chunks_differ = any(actual_data_chunksize[dim] != new_chunking[dim] for dim in new_chunking)
+                if chunks_differ:
+                    logging.warning("You already have data in the object store and you can't rechunk it")
                 # ds_filepath_var = _rechunk_ds(ds_filepath_var, rechunk)
 
             # Append the variable to the object store
             ds_filepath_var.to_zarr(
                 mapper, mode="a", append_dim=append_dim
             )
+            first_file = False
 
         except DuplicatedAppendDimValue:
             logging.info(
@@ -362,15 +377,6 @@ def _send_variable(
                 "Skipping %s due to no %s on data dimensions", dest, append_dim
             )
             return
-
-        data_integrity_evaluation(var,
-                                  append_dim,
-                                  mapper,
-                                  ds_filepath_var,
-                                  dest,
-                                  reproject,
-                                  first_file=False)
-
     except FileNotFoundError:
         logging.info("Creating %s", dest)
         first_file = True
@@ -387,14 +393,15 @@ def _send_variable(
 
         ds_filepath_var.to_zarr(mapper, mode="a")
 
+    if not skip_integrity_check:
         try:
             data_integrity_evaluation(var,
-                                      append_dim,
-                                      mapper,
-                                      ds_filepath_var,
-                                      dest,
-                                      reproject,
-                                      first_file)
+                                    append_dim,
+                                    mapper,
+                                    ds_filepath_var,
+                                    dest,
+                                    reproject,
+                                    first_file)
         except (ExpectedAttrsNotFound, DimensionMismatch, CheckSumMismatch):
             if first_file:
                 logging.warning("No previous version found. The object will be deleted.")
@@ -592,6 +599,7 @@ def _send_data_to_store(
     client: Client,
     rechunk: dict,
     reproject: bool,
+    skip_integrity_check: bool,
     to_zarr_kwargs: dict,
 ) -> None:
     """
@@ -618,10 +626,12 @@ def _send_data_to_store(
         Dask client.
     rechunk
         Rechunk strategy dictionary.
-    to_zarr_kwargs
-        Additional keyword arguments passed to xr.Dataset.to_zarr(), by default None.
     reproject
         Whether to reproject the dataset.
+    skip_integrity_check
+        Whether to skip the data integrity check.
+    to_zarr_kwargs
+        Additional keyword arguments passed to xr.Dataset.to_zarr(), by default None.
     """
     # See https://stackoverflow.com/questions/66769922/concurrently-write-xarray-datasets-to-zarr-how-to-efficiently-scale-with-dask
     if send_vars_indep:
@@ -639,7 +649,8 @@ def _send_data_to_store(
                         object_prefix,
                         append_dim,
                         rechunk,
-                        reproject
+                        reproject,
+                        skip_integrity_check
                     )
                 )
             client.gather(futures)
@@ -653,7 +664,8 @@ def _send_data_to_store(
                     object_prefix,
                     append_dim,
                     rechunk,
-                    reproject
+                    reproject,
+                    skip_integrity_check
                 )
 
     else:

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 import xarray as xr
-import dask.array as da
+import dask
 from fsspec.mapping import FSMap
 
 from .exceptions import (
@@ -314,29 +314,27 @@ def _calculate_checksum(expected_checksum: int,
     Returns:
         int: The expected checksum for the variable.
     """
-    if isinstance(part_of_ds_dataset[var].data, da.Array):
-        data_array = part_of_ds_dataset[var].data.astype(np.uint32)
-        checksum = data_array.sum().compute()
-    else:
-        data_array = da.from_array(part_of_ds_dataset[var].values.astype(np.uint32), chunks='auto')
-    checksum = data_array.sum().compute()
-
-    expected_checksum += checksum
-
+    def calculate_result(var_part_of_ds_dataset):
+        dtype = var_part_of_ds_dataset.data.dtype
+        if np.issubdtype(dtype, np.number):
+            if isinstance(var_part_of_ds_dataset.data, dask.array.core.Array):
+                data_array = var_part_of_ds_dataset.data.astype(np.uint32)
+            else:
+                values = var_part_of_ds_dataset.values
+                values = np.nan_to_num(values, nan=0, posinf=0, neginf=0).astype(np.uint32)
+                data_array = dask.array.from_array(values, chunks='auto')
+            checksum = data_array.sum().compute()
+        else:
+            checksum = 0
+        return checksum
+    expected_checksum += calculate_result(part_of_ds_dataset[var])
 
     # data_bytes = part_of_ds_dataset[var].values
     # checksum = np.frombuffer(data_bytes, dtype=np.uint32).sum()
     # expected_checksum += checksum
     if "y" in list(part_of_ds_dataset.sizes):
         if reproject:
-            if isinstance(part_of_ds_dataset[f"projected_{var}"].data, da.Array):
-                data_array_reprojected = part_of_ds_dataset[f"projected_{var}"].data.astype(np.uint32)
-            else:
-                data_array = da.from_array(part_of_ds_dataset[f"projected_{var}"].values.astype(np.uint32),
-                                           chunks='auto')
-            reprojected_checksum = data_array_reprojected.sum().compute()
-
-            expected_checksum += reprojected_checksum
+            expected_checksum += calculate_result(part_of_ds_dataset[f"projected_{var}"])
             # data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()
             # expected_checksum += np.frombuffer(
             #     data_bytes_reprojected, dtype=np.uint32

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -389,7 +389,6 @@ def _calculate_expected_dimension_size(
     """
     expected_size = {}
     for dim, _ in ds_filepath.sizes.items():
-        logging.info("Dim: %s", dim)
         if dim == append_dim:
             if not ds_obj_store.sizes.get(dim):
                 current_size = 0

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -318,8 +318,8 @@ def _calculate_checksum(expected_checksum: int,
         data_array = part_of_ds_dataset[var].data.astype(np.uint32)
         checksum = data_array.sum().compute()
     else:
-        data_bytes = part_of_ds_dataset[var].values.tobytes()
-        checksum = np.frombuffer(data_bytes, dtype=np.uint32).sum()
+        data_array = da.from_array(part_of_ds_dataset[var].values.astype(np.uint32), chunks='auto')
+    checksum = data_array.sum().compute()
 
     expected_checksum += checksum
 
@@ -331,10 +331,10 @@ def _calculate_checksum(expected_checksum: int,
         if reproject:
             if isinstance(part_of_ds_dataset[f"projected_{var}"].data, da.Array):
                 data_array_reprojected = part_of_ds_dataset[f"projected_{var}"].data.astype(np.uint32)
-                reprojected_checksum = data_array_reprojected.sum().compute()
             else:
-                data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()
-                reprojected_checksum = np.frombuffer(data_bytes_reprojected, dtype=np.uint32).sum()
+                data_array = da.from_array(part_of_ds_dataset[f"projected_{var}"].values.astype(np.uint32),
+                                           chunks='auto')
+            reprojected_checksum = data_array_reprojected.sum().compute()
 
             expected_checksum += reprojected_checksum
             # data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 import xarray as xr
-import dask
+import dask.array
 from fsspec.mapping import FSMap
 
 from .exceptions import (
@@ -315,7 +315,7 @@ def _calculate_checksum(expected_checksum: int,
         int: The expected checksum for the variable.
     """
     def calculate_result(var_part_of_ds_dataset):
-        dtype = var_part_of_ds_dataset.data.dtype
+        dtype = var_part_of_ds_dataset.data.dtype    
         if np.issubdtype(dtype, np.number):
             if isinstance(var_part_of_ds_dataset.data, dask.array.core.Array):
                 data_array = var_part_of_ds_dataset.data.astype(np.uint32)

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -318,7 +318,8 @@ def _calculate_checksum(expected_checksum: int,
         dtype = var_part_of_ds_dataset.data.dtype    
         if np.issubdtype(dtype, np.number):
             if isinstance(var_part_of_ds_dataset.data, dask.array.core.Array):
-                data_array = var_part_of_ds_dataset.data.astype(np.uint32)
+                data_array = part_of_ds_dataset[var].data
+                data_array = dask.array.nan_to_num(data_array, nan=0, posinf=0, neginf=0).astype(np.uint32)
             else:
                 values = var_part_of_ds_dataset.values
                 values = np.nan_to_num(values, nan=0, posinf=0, neginf=0).astype(np.uint32)

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -5,6 +5,7 @@ import logging
 
 import numpy as np
 import xarray as xr
+import dask.array as da
 from fsspec.mapping import FSMap
 
 from .exceptions import (
@@ -313,15 +314,33 @@ def _calculate_checksum(expected_checksum: int,
     Returns:
         int: The expected checksum for the variable.
     """
-    data_bytes = part_of_ds_dataset[var].values
-    checksum = np.frombuffer(data_bytes, dtype=np.uint32).sum()
+    if isinstance(part_of_ds_dataset[var].data, da.Array):
+        data_array = part_of_ds_dataset[var].data.astype(np.uint32)
+        checksum = data_array.sum().compute()
+    else:
+        data_bytes = part_of_ds_dataset[var].values.tobytes()
+        checksum = np.frombuffer(data_bytes, dtype=np.uint32).sum()
+
     expected_checksum += checksum
+
+
+    # data_bytes = part_of_ds_dataset[var].values
+    # checksum = np.frombuffer(data_bytes, dtype=np.uint32).sum()
+    # expected_checksum += checksum
     if "y" in list(part_of_ds_dataset.sizes):
         if reproject:
-            data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()
-            expected_checksum += np.frombuffer(
-                data_bytes_reprojected, dtype=np.uint32
-            ).sum()
+            if isinstance(part_of_ds_dataset[f"projected_{var}"].data, da.Array):
+                data_array_reprojected = part_of_ds_dataset[f"projected_{var}"].data.astype(np.uint32)
+                reprojected_checksum = data_array_reprojected.sum().compute()
+            else:
+                data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()
+                reprojected_checksum = np.frombuffer(data_bytes_reprojected, dtype=np.uint32).sum()
+
+            expected_checksum += reprojected_checksum
+            # data_bytes_reprojected = part_of_ds_dataset[f"projected_{var}"].values.tobytes()
+            # expected_checksum += np.frombuffer(
+            #     data_bytes_reprojected, dtype=np.uint32
+            # ).sum()
     return expected_checksum
 
     # else:

--- a/src/msm_os/sanity_checks.py
+++ b/src/msm_os/sanity_checks.py
@@ -315,11 +315,14 @@ def _calculate_checksum(expected_checksum: int,
         int: The expected checksum for the variable.
     """
     def calculate_result(var_part_of_ds_dataset):
-        dtype = var_part_of_ds_dataset.data.dtype    
+        dtype = var_part_of_ds_dataset.data.dtype
         if np.issubdtype(dtype, np.number):
             if isinstance(var_part_of_ds_dataset.data, dask.array.core.Array):
                 data_array = part_of_ds_dataset[var].data
-                data_array = dask.array.nan_to_num(data_array, nan=0, posinf=0, neginf=0).astype(np.uint32)
+                data_array = dask.array.where(dask.array.isnan(data_array), 0, data_array)
+                data_array = dask.array.where(data_array == np.inf, 0, data_array)
+                data_array = dask.array.where(data_array == -np.inf, 0, data_array)
+                data_array = data_array.astype(np.uint32)
             else:
                 values = var_part_of_ds_dataset.values
                 values = np.nan_to_num(values, nan=0, posinf=0, neginf=0).astype(np.uint32)


### PR DESCRIPTION
1. **Flag to suppress integrity checks**: Added a new flag `skip_integrity_check` (`-si` or `--skip-integrity-check`). By default, it's set to `False` (integrity checks are applied). I'll update the NEMO_CYLC documentation and codes accordingly.

2. **Dask integration for checksum calculation**: I've integrated Dask for the checksum calculation, which in my tests has shown a 2-5x speed improvement. However, this performance boost will vary depending on the machine and whether Dask is already being used to load data into the object store.

3. **Suppress unwarranted warnings**: I’ve adjusted the warning so it will only appear if the chunk strategy being applied differs from the original one. No warnings will be shown if the chunk strategy remains unchanged.
